### PR TITLE
feat(datasets): add support for stacked charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-charts-css` will be documented in this file.
 
+## 1.2.0 - 2021-07-17
+
+- Added support for simple stacked and percentage stacked datasets.
+
 ## 1.1.0 - 2021-07-08
 
 - Added abstract `AreaChart`, `BarChart` and `LineChart` classes.

--- a/README.md
+++ b/README.md
@@ -293,6 +293,43 @@ protected function datasets(): DatasetsContract
 
 You can align a dataset's label by calling the `alignLabel()` method on a dataset with `start`, `center` or `end` as parameter.
 
+#### Stacked datasets
+
+```php
+use Maartenpaauw\Chartscss\Data\Axes\Axes;
+use Maartenpaauw\Chartscss\Data\Datasets\Dataset;
+use Maartenpaauw\Chartscss\Data\Datasets\Datasets;
+use Maartenpaauw\Chartscss\Data\Datasets\DatasetsContract;
+use Maartenpaauw\Chartscss\Data\Datasets\PercentageStackedDatasets;
+use Maartenpaauw\Chartscss\Data\Entries\Entry;
+use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
+use Maartenpaauw\Chartscss\Data\Label\Label;
+
+// ...
+
+protected function datasets(): DatasetsContract
+{
+    return new PercentageStackedDatasets(
+        new Datasets(
+            new Axes('Country', ['Gold', 'Silver', 'Bronze']),
+            new Dataset([
+                new Entry(new Value(46)),
+                new Entry(new Value(37)),
+                new Entry(new Value(38)),
+            ], new Label('USA')),
+            new Dataset([
+                new Entry(new Value(27)),
+                new Entry(new Value(23)),
+                new Entry(new Value(17)),
+            ], new Label('GBR')),
+        ),
+    );
+}
+```
+
+If you want your chart data to be stacked, you can wrap the datasets instance within a `SimpleStackedDatasets` or a
+`PercentageStackedDatasets` decorator. The smart configuration will automatically add the `Stacked` modification.
+
 ### Stylesheet
 
 > **Warning!** Make sure you insert this component within your base layout template where your chart is not directly used.
@@ -668,7 +705,8 @@ protected function modifications(): Modifications
 }
 ````
 
-If you want to stack multiple datasets you can add the `Stacked` modification.
+If you want to stack multiple datasets you can add the `Stacked` modification. This is done automatically (via the smart
+configuration) if you wrapped your datasets instance within a `SimpleStackedDatasets` or `PercentageStackedDatasets` decorator
 
 #### Did I miss adding a modification?
 
@@ -693,6 +731,9 @@ In the meanwhile you can add it easily by adding a `CustomModification`.
 As mentioned before, the configuration is pretty smart. It adds a `ShowHeading` modification if a heading is present,
 adds the modifications `Multiple` when multiple datasets are present, it adds the `ShowLabels` modification when there
 are dataset or entry labels defined, and it uses the configured data axes as legend labels when none has been specified.
+
+If you wrap your datasets instance within a `SimpleStackedDatasets` or `PercentageStackedDatasets` decorator, it will
+automatically add the `Stacked` modification.
 
 This is done by wrapping the configuration within a `SmartConfiguration` decorator. If you do not want this behaviour
 you can overwrite the `configuration` method and build the configuration by yourself.

--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -14,20 +14,20 @@
     @endif
     <tbody>
         @foreach($datasets->toArray() as $dataset)
-            @if($datasets->size() === 1)
-                @foreach($dataset->entries() as $entry)
-                    <tr>
-                        <x-charts-css-label :label="$entry->label()" />
-                        <x-charts-css-entry :entry="$entry" />
-                    </tr>
-                @endforeach
-            @else
+            @if((new \Maartenpaauw\Chartscss\Data\Specifications\HasMultiple())->isSatisfiedBy($datasets))
                 <tr>
                     <x-charts-css-label :label="$dataset->label()" />
                     @foreach($dataset->entries() as $entry)
                         <x-charts-css-entry :entry="$entry" />
                     @endforeach
                 </tr>
+            @else
+                @foreach($dataset->entries() as $entry)
+                    <tr>
+                        <x-charts-css-label :label="$entry->label()" />
+                        <x-charts-css-entry :entry="$entry" />
+                    </tr>
+                @endforeach
             @endif
         @endforeach
     </tbody>

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -14,8 +14,10 @@ use Maartenpaauw\Chartscss\Configuration\Specifications\NeedsStartingPoint;
 use Maartenpaauw\Chartscss\Data\Datasets\CalculatedDatasets;
 use Maartenpaauw\Chartscss\Data\Datasets\DatasetsContract;
 use Maartenpaauw\Chartscss\Data\Datasets\StartingPointDatasets;
+use Maartenpaauw\Chartscss\Data\Specifications\IsStacked;
 use Maartenpaauw\Chartscss\Identity\Identity;
 use Maartenpaauw\Chartscss\Legend\Legend;
+use Maartenpaauw\Chartscss\Specifications\NotSpecification;
 use Maartenpaauw\Chartscss\Types\ChartType;
 use Maartenpaauw\Chartscss\Types\Column;
 
@@ -78,13 +80,17 @@ abstract class Chart extends Component
 
     private function prepareDatasets(): DatasetsContract
     {
-        $calculatedDatasets = new CalculatedDatasets($this->datasets());
+        $datasets = $this->datasets();
 
-        if ((new NeedsStartingPoint())->isSatisfiedBy($this->configuration())) {
-            return new StartingPointDatasets($calculatedDatasets);
+        if ((new NotSpecification(new IsStacked()))->isSatisfiedBy($datasets)) {
+            $datasets = new CalculatedDatasets($datasets);
         }
 
-        return $calculatedDatasets;
+        if ((new NeedsStartingPoint())->isSatisfiedBy($this->configuration())) {
+            $datasets = new StartingPointDatasets($datasets);
+        }
+
+        return $datasets;
     }
 
     public function render(): View

--- a/src/Configuration/SmartConfiguration.php
+++ b/src/Configuration/SmartConfiguration.php
@@ -7,12 +7,14 @@ use Maartenpaauw\Chartscss\Appearance\Modifications;
 use Maartenpaauw\Chartscss\Appearance\Multiple;
 use Maartenpaauw\Chartscss\Appearance\ShowHeading;
 use Maartenpaauw\Chartscss\Appearance\ShowLabels;
+use Maartenpaauw\Chartscss\Appearance\Stacked;
 use Maartenpaauw\Chartscss\Configuration\Specifications\HasHeading;
 use Maartenpaauw\Chartscss\Configuration\Specifications\HasLabels;
 use Maartenpaauw\Chartscss\Data\Datasets\DatasetsContract;
 use Maartenpaauw\Chartscss\Data\Specifications\HasDatasetLabels;
 use Maartenpaauw\Chartscss\Data\Specifications\HasEntryLabels;
 use Maartenpaauw\Chartscss\Data\Specifications\HasMultiple;
+use Maartenpaauw\Chartscss\Data\Specifications\IsStacked;
 use Maartenpaauw\Chartscss\Identity\Identity;
 use Maartenpaauw\Chartscss\Legend\Legend;
 use Maartenpaauw\Chartscss\Specifications\AndSpecification;
@@ -59,6 +61,10 @@ class SmartConfiguration implements ConfigurationContract
 
         if ($this->hasDataLabels()) {
             $modifications = $modifications->add(new ShowLabels());
+        }
+
+        if ((new IsStacked())->isSatisfiedBy($this->datasets)) {
+            $modifications = $modifications->add(new Stacked());
         }
 
         return $modifications;

--- a/src/Data/Dataset/Statistics/HighestEntryStatistic.php
+++ b/src/Data/Dataset/Statistics/HighestEntryStatistic.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Data\Dataset\Statistics;
+
+use Maartenpaauw\Chartscss\Data\Datasets\DatasetContract;
+use Maartenpaauw\Chartscss\Data\Entries\EntryContract;
+use Maartenpaauw\Chartscss\Statistics\StatisticContract;
+
+class HighestEntryStatistic implements StatisticContract
+{
+    private DatasetContract $dataset;
+
+    public function __construct(DatasetContract $dataset)
+    {
+        $this->dataset = $dataset;
+    }
+
+    public function result(): float
+    {
+        return max(
+            array_map(
+                fn (EntryContract $entry) => $entry->value()->raw(),
+                $this->dataset->entries(),
+            ),
+        );
+    }
+}

--- a/src/Data/Dataset/Statistics/SumStatistic.php
+++ b/src/Data/Dataset/Statistics/SumStatistic.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Data\Dataset\Statistics;
+
+use Maartenpaauw\Chartscss\Data\Datasets\DatasetContract;
+use Maartenpaauw\Chartscss\Data\Entries\EntryContract;
+use Maartenpaauw\Chartscss\Statistics\StatisticContract;
+
+class SumStatistic implements StatisticContract
+{
+    private DatasetContract $dataset;
+
+    public function __construct(DatasetContract $dataset)
+    {
+        $this->dataset = $dataset;
+    }
+
+    public function result(): float
+    {
+        return array_sum(
+            array_map(
+                fn (EntryContract $entry) => $entry->value()->raw(),
+                $this->dataset->entries(),
+            ),
+        );
+    }
+}

--- a/src/Data/Datasets/CalculatedDataset.php
+++ b/src/Data/Datasets/CalculatedDataset.php
@@ -5,29 +5,25 @@ namespace Maartenpaauw\Chartscss\Data\Datasets;
 use Maartenpaauw\Chartscss\Data\Entries\CalculatedEntry;
 use Maartenpaauw\Chartscss\Data\Entries\EntryContract;
 use Maartenpaauw\Chartscss\Data\Label\LabelContract;
+use Maartenpaauw\Chartscss\Statistics\StatisticContract;
 
 class CalculatedDataset implements DatasetContract
 {
     private DatasetContract $origin;
 
-    private float $max;
+    private StatisticContract $maximum;
 
-    public function __construct(DatasetContract $origin, float $max)
+    public function __construct(DatasetContract $origin, StatisticContract $maximum)
     {
         $this->origin = $origin;
-        $this->max = $max;
+        $this->maximum = $maximum;
     }
 
     public function entries(): array
     {
         return array_map(function (EntryContract $entry) {
-            return new CalculatedEntry($entry, $this->max);
+            return new CalculatedEntry($entry, $this->maximum);
         }, $this->origin->entries());
-    }
-
-    public function max(): float
-    {
-        return $this->origin->max();
     }
 
     public function label(): LabelContract

--- a/src/Data/Datasets/Dataset.php
+++ b/src/Data/Datasets/Dataset.php
@@ -2,7 +2,6 @@
 
 namespace Maartenpaauw\Chartscss\Data\Datasets;
 
-use Maartenpaauw\Chartscss\Data\Entries\EntryContract;
 use Maartenpaauw\Chartscss\Data\Label\AlignedLabel;
 use Maartenpaauw\Chartscss\Data\Label\HiddenLabel;
 use Maartenpaauw\Chartscss\Data\Label\LabelContract;
@@ -28,11 +27,6 @@ class Dataset implements DatasetContract
     public function label(): LabelContract
     {
         return $this->label;
-    }
-
-    public function max(): float
-    {
-        return max(array_merge([0], array_map(fn (EntryContract $entry) => $entry->value()->raw(), $this->entries)));
     }
 
     public function hideLabel(): Dataset

--- a/src/Data/Datasets/DatasetContract.php
+++ b/src/Data/Datasets/DatasetContract.php
@@ -13,6 +13,4 @@ interface DatasetContract
     public function entries(): array;
 
     public function label(): LabelContract;
-
-    public function max(): float;
 }

--- a/src/Data/Datasets/Datasets.php
+++ b/src/Data/Datasets/Datasets.php
@@ -19,16 +19,6 @@ class Datasets implements DatasetsContract
         $this->datasets = $datasets;
     }
 
-    public function size(): int
-    {
-        return count($this->datasets);
-    }
-
-    public function max(): float
-    {
-        return max(array_map(fn (DatasetContract $dataset) => $dataset->max(), $this->datasets));
-    }
-
     public function axes(): AxesContract
     {
         return $this->axes;

--- a/src/Data/Datasets/DatasetsContract.php
+++ b/src/Data/Datasets/DatasetsContract.php
@@ -6,10 +6,6 @@ use Maartenpaauw\Chartscss\Data\Axes\AxesContract;
 
 interface DatasetsContract
 {
-    public function size(): int;
-
-    public function max(): float;
-
     public function axes(): AxesContract;
 
     /**

--- a/src/Data/Datasets/PercentageStackedDatasets.php
+++ b/src/Data/Datasets/PercentageStackedDatasets.php
@@ -3,9 +3,9 @@
 namespace Maartenpaauw\Chartscss\Data\Datasets;
 
 use Maartenpaauw\Chartscss\Data\Axes\AxesContract;
-use Maartenpaauw\Chartscss\Data\Datasets\Statistics\HighestEntryStatistic;
+use Maartenpaauw\Chartscss\Data\Dataset\Statistics\SumStatistic;
 
-class CalculatedDatasets implements DatasetsContract
+class PercentageStackedDatasets implements DatasetsContract
 {
     private DatasetsContract $origin;
 
@@ -22,7 +22,7 @@ class CalculatedDatasets implements DatasetsContract
     public function toArray(): array
     {
         return array_map(function (DatasetContract $dataset) {
-            return new CalculatedDataset($dataset, new HighestEntryStatistic($this->origin));
+            return new CalculatedDataset($dataset, new SumStatistic($dataset));
         }, $this->origin->toArray());
     }
 }

--- a/src/Data/Datasets/SimpleStackedDatasets.php
+++ b/src/Data/Datasets/SimpleStackedDatasets.php
@@ -3,9 +3,9 @@
 namespace Maartenpaauw\Chartscss\Data\Datasets;
 
 use Maartenpaauw\Chartscss\Data\Axes\AxesContract;
-use Maartenpaauw\Chartscss\Data\Datasets\Statistics\HighestEntryStatistic;
+use Maartenpaauw\Chartscss\Data\Datasets\Statistics\HighestDatasetSumStatistic;
 
-class CalculatedDatasets implements DatasetsContract
+class SimpleStackedDatasets implements DatasetsContract
 {
     private DatasetsContract $origin;
 
@@ -22,7 +22,7 @@ class CalculatedDatasets implements DatasetsContract
     public function toArray(): array
     {
         return array_map(function (DatasetContract $dataset) {
-            return new CalculatedDataset($dataset, new HighestEntryStatistic($this->origin));
+            return new CalculatedDataset($dataset, new HighestDatasetSumStatistic($this->origin));
         }, $this->origin->toArray());
     }
 }

--- a/src/Data/Datasets/StartingPointDataset.php
+++ b/src/Data/Datasets/StartingPointDataset.php
@@ -5,17 +5,18 @@ namespace Maartenpaauw\Chartscss\Data\Datasets;
 use Maartenpaauw\Chartscss\Data\Entries\EntryContract;
 use Maartenpaauw\Chartscss\Data\Entries\StartingPointEntry;
 use Maartenpaauw\Chartscss\Data\Label\LabelContract;
+use Maartenpaauw\Chartscss\Statistics\StatisticContract;
 
 class StartingPointDataset implements DatasetContract
 {
     private DatasetContract $origin;
 
-    private float $max;
+    private StatisticContract $maximum;
 
-    public function __construct(DatasetContract $origin, float $max)
+    public function __construct(DatasetContract $origin, StatisticContract $maximum)
     {
         $this->origin = $origin;
-        $this->max = $max;
+        $this->maximum = $maximum;
     }
 
     public function entries(): array
@@ -28,13 +29,8 @@ class StartingPointDataset implements DatasetContract
         $first = array_shift($entries);
 
         return array_merge([$first], array_map(function (EntryContract $entry, int $key) use ($first, $entries) {
-            return new StartingPointEntry($entry, $entries[--$key] ?? $first, $this->max);
+            return new StartingPointEntry($entry, $entries[--$key] ?? $first, $this->maximum);
         }, $entries, array_keys($entries)));
-    }
-
-    public function max(): float
-    {
-        return $this->origin->max();
     }
 
     public function label(): LabelContract

--- a/src/Data/Datasets/StartingPointDatasets.php
+++ b/src/Data/Datasets/StartingPointDatasets.php
@@ -3,6 +3,7 @@
 namespace Maartenpaauw\Chartscss\Data\Datasets;
 
 use Maartenpaauw\Chartscss\Data\Axes\AxesContract;
+use Maartenpaauw\Chartscss\Data\Datasets\Statistics\HighestEntryStatistic;
 
 class StartingPointDatasets implements DatasetsContract
 {
@@ -13,16 +14,6 @@ class StartingPointDatasets implements DatasetsContract
         $this->origin = $origin;
     }
 
-    public function size(): int
-    {
-        return $this->origin->size();
-    }
-
-    public function max(): float
-    {
-        return $this->origin->max();
-    }
-
     public function axes(): AxesContract
     {
         return $this->origin->axes();
@@ -31,7 +22,7 @@ class StartingPointDatasets implements DatasetsContract
     public function toArray(): array
     {
         return array_map(function (DatasetContract $dataset) {
-            return new StartingPointDataset($dataset, $this->origin->max());
+            return new StartingPointDataset($dataset, new HighestEntryStatistic($this->origin));
         }, $this->origin->toArray());
     }
 }

--- a/src/Data/Datasets/Statistics/HighestDatasetSumStatistic.php
+++ b/src/Data/Datasets/Statistics/HighestDatasetSumStatistic.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Data\Datasets\Statistics;
+
+use Maartenpaauw\Chartscss\Data\Dataset\Statistics\SumStatistic;
+use Maartenpaauw\Chartscss\Data\Datasets\DatasetContract;
+use Maartenpaauw\Chartscss\Data\Datasets\DatasetsContract;
+use Maartenpaauw\Chartscss\Statistics\StatisticContract;
+
+class HighestDatasetSumStatistic implements StatisticContract
+{
+    private DatasetsContract $datasets;
+
+    public function __construct(DatasetsContract $datasets)
+    {
+        $this->datasets = $datasets;
+    }
+
+    public function result(): float
+    {
+        return max(
+            array_map(
+                fn (DatasetContract $dataset) => (new SumStatistic($dataset))->result(),
+                $this->datasets->toArray(),
+            ),
+        );
+    }
+}

--- a/src/Data/Datasets/Statistics/HighestEntryStatistic.php
+++ b/src/Data/Datasets/Statistics/HighestEntryStatistic.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Data\Datasets\Statistics;
+
+use Maartenpaauw\Chartscss\Data\Dataset\Statistics\HighestEntryStatistic as HighestDatasetEntryStatistic;
+use Maartenpaauw\Chartscss\Data\Datasets\DatasetContract;
+use Maartenpaauw\Chartscss\Data\Datasets\DatasetsContract;
+use Maartenpaauw\Chartscss\Statistics\StatisticContract;
+
+class HighestEntryStatistic implements StatisticContract
+{
+    private DatasetsContract $datasets;
+
+    public function __construct(DatasetsContract $datasets)
+    {
+        $this->datasets = $datasets;
+    }
+
+    public function result(): float
+    {
+        return max(
+            array_map(
+                fn (DatasetContract $dataset) => (new HighestDatasetEntryStatistic($dataset))->result(),
+                $this->datasets->toArray(),
+            )
+        );
+    }
+}

--- a/src/Data/Entries/CalculatedEntry.php
+++ b/src/Data/Entries/CalculatedEntry.php
@@ -6,24 +6,25 @@ use Maartenpaauw\Chartscss\Data\Entries\Tooltip\TooltipContract;
 use Maartenpaauw\Chartscss\Data\Entries\Value\SizedValue;
 use Maartenpaauw\Chartscss\Data\Entries\Value\ValueContract;
 use Maartenpaauw\Chartscss\Data\Label\LabelContract;
+use Maartenpaauw\Chartscss\Statistics\StatisticContract;
 
 class CalculatedEntry implements EntryContract
 {
     private EntryContract $origin;
 
-    private float $max;
+    private StatisticContract $maximum;
 
-    public function __construct(EntryContract $origin, float $max)
+    public function __construct(EntryContract $origin, StatisticContract $maximum)
     {
         $this->origin = $origin;
-        $this->max = $max;
+        $this->maximum = $maximum;
     }
 
     public function value(): ValueContract
     {
         return new SizedValue(
             $this->origin->value(),
-            $this->max,
+            $this->maximum->result(),
         );
     }
 

--- a/src/Data/Entries/StartingPointEntry.php
+++ b/src/Data/Entries/StartingPointEntry.php
@@ -6,6 +6,7 @@ use Maartenpaauw\Chartscss\Data\Entries\Tooltip\TooltipContract;
 use Maartenpaauw\Chartscss\Data\Entries\Value\StartValue;
 use Maartenpaauw\Chartscss\Data\Entries\Value\ValueContract;
 use Maartenpaauw\Chartscss\Data\Label\LabelContract;
+use Maartenpaauw\Chartscss\Statistics\StatisticContract;
 
 class StartingPointEntry implements EntryContract
 {
@@ -13,13 +14,13 @@ class StartingPointEntry implements EntryContract
 
     private EntryContract $previous;
 
-    private float $max;
+    private StatisticContract $maximum;
 
-    public function __construct(EntryContract $origin, EntryContract $previous, float $max)
+    public function __construct(EntryContract $origin, EntryContract $previous, StatisticContract $maximum)
     {
         $this->origin = $origin;
         $this->previous = $previous;
-        $this->max = $max;
+        $this->maximum = $maximum;
     }
 
     public function value(): ValueContract
@@ -27,7 +28,7 @@ class StartingPointEntry implements EntryContract
         return new StartValue(
             $this->origin->value(),
             $this->previous->value()->raw(),
-            $this->max,
+            $this->maximum->result(),
         );
     }
 

--- a/src/Data/Specifications/HasMultiple.php
+++ b/src/Data/Specifications/HasMultiple.php
@@ -8,6 +8,6 @@ class HasMultiple implements DatasetsSpecification
 {
     public function isSatisfiedBy(DatasetsContract $datasets): bool
     {
-        return $datasets->size() > 1;
+        return count($datasets->toArray()) > 1;
     }
 }

--- a/src/Data/Specifications/IsStacked.php
+++ b/src/Data/Specifications/IsStacked.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Data\Specifications;
+
+use Maartenpaauw\Chartscss\Data\Datasets\DatasetsContract;
+use Maartenpaauw\Chartscss\Data\Datasets\PercentageStackedDatasets;
+use Maartenpaauw\Chartscss\Data\Datasets\SimpleStackedDatasets;
+
+class IsStacked implements DatasetsSpecification
+{
+    public function isSatisfiedBy(DatasetsContract $datasets): bool
+    {
+        return in_array(get_class($datasets), [
+            SimpleStackedDatasets::class,
+            PercentageStackedDatasets::class,
+        ]);
+    }
+}

--- a/src/Examples/Stacked/StackedExample1.php
+++ b/src/Examples/Stacked/StackedExample1.php
@@ -20,6 +20,7 @@ use Maartenpaauw\Chartscss\Data\Axes\Axes;
 use Maartenpaauw\Chartscss\Data\Datasets\Dataset;
 use Maartenpaauw\Chartscss\Data\Datasets\Datasets;
 use Maartenpaauw\Chartscss\Data\Datasets\DatasetsContract;
+use Maartenpaauw\Chartscss\Data\Datasets\SimpleStackedDatasets;
 use Maartenpaauw\Chartscss\Data\Entries\Entry;
 use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
 use Maartenpaauw\Chartscss\Data\Label\Label;
@@ -38,32 +39,34 @@ class StackedExample1 extends BarChart
 
     protected function datasets(): DatasetsContract
     {
-        return new Datasets(
-            new Axes('continent', ['#1', '#2', '#3', '#4']),
-            new Dataset([
-                new Entry(new Value(50, '50$')),
-                new Entry(new Value(50, '50$')),
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(20, '20$')),
-            ], new Label('America')),
-            new Dataset([
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(30, '30$')),
-            ], new Label('Asia')),
-            new Dataset([
-                new Entry(new Value(40, '40$')),
-                new Entry(new Value(25, '25$')),
-                new Entry(new Value(45, '45$')),
-                new Entry(new Value(30, '30$')),
-            ], new Label('Europe')),
-            new Dataset([
-                new Entry(new Value(20, '20')),
-                new Entry(new Value(20, '20')),
-                new Entry(new Value(20, '20')),
-                new Entry(new Value(20, '20')),
-            ], new Label('Africa')),
+        return new SimpleStackedDatasets(
+            new Datasets(
+                new Axes('continent', ['#1', '#2', '#3', '#4']),
+                new Dataset([
+                    new Entry(new Value(50, '50$')),
+                    new Entry(new Value(50, '50$')),
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(20, '20$')),
+                ], new Label('America')),
+                new Dataset([
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(30, '30$')),
+                ], new Label('Asia')),
+                new Dataset([
+                    new Entry(new Value(40, '40$')),
+                    new Entry(new Value(25, '25$')),
+                    new Entry(new Value(45, '45$')),
+                    new Entry(new Value(30, '30$')),
+                ], new Label('Europe')),
+                new Dataset([
+                    new Entry(new Value(20, '20')),
+                    new Entry(new Value(20, '20')),
+                    new Entry(new Value(20, '20')),
+                    new Entry(new Value(20, '20')),
+                ], new Label('Africa')),
+            ),
         );
     }
 

--- a/src/Examples/Stacked/StackedExample2.php
+++ b/src/Examples/Stacked/StackedExample2.php
@@ -20,6 +20,7 @@ use Maartenpaauw\Chartscss\Data\Axes\Axes;
 use Maartenpaauw\Chartscss\Data\Datasets\Dataset;
 use Maartenpaauw\Chartscss\Data\Datasets\Datasets;
 use Maartenpaauw\Chartscss\Data\Datasets\DatasetsContract;
+use Maartenpaauw\Chartscss\Data\Datasets\PercentageStackedDatasets;
 use Maartenpaauw\Chartscss\Data\Entries\Entry;
 use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
 use Maartenpaauw\Chartscss\Data\Label\Label;
@@ -38,32 +39,34 @@ class StackedExample2 extends BarChart
 
     protected function datasets(): DatasetsContract
     {
-        return new Datasets(
-            new Axes('continent', ['#1', '#2', '#3', '#4']),
-            new Dataset([
-                new Entry(new Value(50, '50$')),
-                new Entry(new Value(50, '50$')),
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(20, '20$')),
-            ], new Label('America')),
-            new Dataset([
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(30, '30$')),
-            ], new Label('Asia')),
-            new Dataset([
-                new Entry(new Value(40, '40$')),
-                new Entry(new Value(25, '25$')),
-                new Entry(new Value(45, '45$')),
-                new Entry(new Value(30, '30$')),
-            ], new Label('Europe')),
-            new Dataset([
-                new Entry(new Value(20, '20')),
-                new Entry(new Value(20, '20')),
-                new Entry(new Value(20, '20')),
-                new Entry(new Value(20, '20')),
-            ], new Label('Africa')),
+        return new PercentageStackedDatasets(
+            new Datasets(
+                new Axes('continent', ['#1', '#2', '#3', '#4']),
+                new Dataset([
+                    new Entry(new Value(50, '50$')),
+                    new Entry(new Value(50, '50$')),
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(20, '20$')),
+                ], new Label('America')),
+                new Dataset([
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(30, '30$')),
+                ], new Label('Asia')),
+                new Dataset([
+                    new Entry(new Value(40, '40$')),
+                    new Entry(new Value(25, '25$')),
+                    new Entry(new Value(45, '45$')),
+                    new Entry(new Value(30, '30$')),
+                ], new Label('Europe')),
+                new Dataset([
+                    new Entry(new Value(20, '20')),
+                    new Entry(new Value(20, '20')),
+                    new Entry(new Value(20, '20')),
+                    new Entry(new Value(20, '20')),
+                ], new Label('Africa')),
+            ),
         );
     }
 

--- a/src/Examples/Stacked/StackedExample3.php
+++ b/src/Examples/Stacked/StackedExample3.php
@@ -20,6 +20,7 @@ use Maartenpaauw\Chartscss\Data\Axes\Axes;
 use Maartenpaauw\Chartscss\Data\Datasets\Dataset;
 use Maartenpaauw\Chartscss\Data\Datasets\Datasets;
 use Maartenpaauw\Chartscss\Data\Datasets\DatasetsContract;
+use Maartenpaauw\Chartscss\Data\Datasets\SimpleStackedDatasets;
 use Maartenpaauw\Chartscss\Data\Entries\Entry;
 use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
 use Maartenpaauw\Chartscss\Data\Label\Label;
@@ -38,32 +39,34 @@ class StackedExample3 extends Chart
 
     protected function datasets(): DatasetsContract
     {
-        return new Datasets(
-            new Axes('continent', ['#1', '#2', '#3', '#4']),
-            new Dataset([
-                new Entry(new Value(50, '50$')),
-                new Entry(new Value(50, '50$')),
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(20, '20$')),
-            ], new Label('America')),
-            new Dataset([
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(30, '30$')),
-            ], new Label('Asia')),
-            new Dataset([
-                new Entry(new Value(40, '40$')),
-                new Entry(new Value(25, '25$')),
-                new Entry(new Value(45, '45$')),
-                new Entry(new Value(30, '30$')),
-            ], new Label('Europe')),
-            new Dataset([
-                new Entry(new Value(20, '20')),
-                new Entry(new Value(20, '20')),
-                new Entry(new Value(20, '20')),
-                new Entry(new Value(20, '20')),
-            ], new Label('Africa')),
+        return new SimpleStackedDatasets(
+            new Datasets(
+                new Axes('continent', ['#1', '#2', '#3', '#4']),
+                new Dataset([
+                    new Entry(new Value(50, '50$')),
+                    new Entry(new Value(50, '50$')),
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(20, '20$')),
+                ], new Label('America')),
+                new Dataset([
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(30, '30$')),
+                ], new Label('Asia')),
+                new Dataset([
+                    new Entry(new Value(40, '40$')),
+                    new Entry(new Value(25, '25$')),
+                    new Entry(new Value(45, '45$')),
+                    new Entry(new Value(30, '30$')),
+                ], new Label('Europe')),
+                new Dataset([
+                    new Entry(new Value(20, '20')),
+                    new Entry(new Value(20, '20')),
+                    new Entry(new Value(20, '20')),
+                    new Entry(new Value(20, '20')),
+                ], new Label('Africa')),
+            ),
         );
     }
 

--- a/src/Examples/Stacked/StackedExample4.php
+++ b/src/Examples/Stacked/StackedExample4.php
@@ -20,6 +20,7 @@ use Maartenpaauw\Chartscss\Data\Axes\Axes;
 use Maartenpaauw\Chartscss\Data\Datasets\Dataset;
 use Maartenpaauw\Chartscss\Data\Datasets\Datasets;
 use Maartenpaauw\Chartscss\Data\Datasets\DatasetsContract;
+use Maartenpaauw\Chartscss\Data\Datasets\PercentageStackedDatasets;
 use Maartenpaauw\Chartscss\Data\Entries\Entry;
 use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
 use Maartenpaauw\Chartscss\Data\Label\Label;
@@ -38,32 +39,34 @@ class StackedExample4 extends Chart
 
     protected function datasets(): DatasetsContract
     {
-        return new Datasets(
-            new Axes('continent', ['#1', '#2', '#3', '#4']),
-            new Dataset([
-                new Entry(new Value(50, '50$')),
-                new Entry(new Value(50, '50$')),
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(20, '20$')),
-            ], new Label('America')),
-            new Dataset([
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(30, '30$')),
-                new Entry(new Value(30, '30$')),
-            ], new Label('Asia')),
-            new Dataset([
-                new Entry(new Value(40, '40$')),
-                new Entry(new Value(25, '25$')),
-                new Entry(new Value(45, '45$')),
-                new Entry(new Value(30, '30$')),
-            ], new Label('Europe')),
-            new Dataset([
-                new Entry(new Value(20, '20')),
-                new Entry(new Value(20, '20')),
-                new Entry(new Value(20, '20')),
-                new Entry(new Value(20, '20')),
-            ], new Label('Africa')),
+        return new PercentageStackedDatasets(
+            new Datasets(
+                new Axes('continent', ['#1', '#2', '#3', '#4']),
+                new Dataset([
+                    new Entry(new Value(50, '50$')),
+                    new Entry(new Value(50, '50$')),
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(20, '20$')),
+                ], new Label('America')),
+                new Dataset([
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(30, '30$')),
+                    new Entry(new Value(30, '30$')),
+                ], new Label('Asia')),
+                new Dataset([
+                    new Entry(new Value(40, '40$')),
+                    new Entry(new Value(25, '25$')),
+                    new Entry(new Value(45, '45$')),
+                    new Entry(new Value(30, '30$')),
+                ], new Label('Europe')),
+                new Dataset([
+                    new Entry(new Value(20, '20')),
+                    new Entry(new Value(20, '20')),
+                    new Entry(new Value(20, '20')),
+                    new Entry(new Value(20, '20')),
+                ], new Label('Africa')),
+            ),
         );
     }
 

--- a/src/Statistics/CustomStatistic.php
+++ b/src/Statistics/CustomStatistic.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Statistics;
+
+class CustomStatistic implements StatisticContract
+{
+    private float $value;
+
+    public function __construct(float $value)
+    {
+        $this->value = $value;
+    }
+
+    public function result(): float
+    {
+        return $this->value;
+    }
+}

--- a/src/Statistics/StatisticContract.php
+++ b/src/Statistics/StatisticContract.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Statistics;
+
+interface StatisticContract
+{
+    public function result(): float;
+}

--- a/tests/Data/Dataset/Statistics/HighestEntryStatisticTest.php
+++ b/tests/Data/Dataset/Statistics/HighestEntryStatisticTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Tests\Data\Dataset\Statistics;
+
+use Maartenpaauw\Chartscss\Data\Dataset\Statistics\HighestEntryStatistic;
+use Maartenpaauw\Chartscss\Data\Datasets\Dataset;
+use Maartenpaauw\Chartscss\Data\Entries\Entry;
+use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
+use Maartenpaauw\Chartscss\Tests\TestCase;
+
+class HighestEntryStatisticTest extends TestCase
+{
+    /** @test */
+    public function it_should_return_the_highest_entry_of_a_given_dataset(): void
+    {
+        // Arrange
+        $expectedResult = 50;
+
+        $dataset = new Dataset([
+            new Entry(new Value(30)),
+            new Entry(new Value(10)),
+            new Entry(new Value(50)),
+            new Entry(new Value(40)),
+        ]);
+
+        $highestEntryStatistic = new HighestEntryStatistic($dataset);
+
+        // Act
+        $result = $highestEntryStatistic->result();
+
+        // Assert
+        $this->assertEquals($expectedResult, $result);
+    }
+}

--- a/tests/Data/Dataset/Statistics/SumStatisticTest.php
+++ b/tests/Data/Dataset/Statistics/SumStatisticTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Tests\Data\Dataset\Statistics;
+
+use Maartenpaauw\Chartscss\Data\Dataset\Statistics\SumStatistic;
+use Maartenpaauw\Chartscss\Data\Datasets\Dataset;
+use Maartenpaauw\Chartscss\Data\Entries\Entry;
+use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
+use Maartenpaauw\Chartscss\Tests\TestCase;
+
+class SumStatisticTest extends TestCase
+{
+    /** @test */
+    public function it_should_return_the_sum_of_the_given_dataset_entries(): void
+    {
+        // Arrange
+        $expectedResult = 130;
+
+        $dataset = new Dataset([
+            new Entry(new Value(30)),
+            new Entry(new Value(10)),
+            new Entry(new Value(50)),
+            new Entry(new Value(40)),
+        ]);
+
+        $sumStatistic = new SumStatistic($dataset);
+
+        // Act
+        $result = $sumStatistic->result();
+
+        // Assert
+        $this->assertEquals($expectedResult, $result);
+    }
+}

--- a/tests/Data/Datasets/CalculatedDatasetTest.php
+++ b/tests/Data/Datasets/CalculatedDatasetTest.php
@@ -5,9 +5,11 @@ namespace Maartenpaauw\Chartscss\Tests\Data\Datasets;
 use Maartenpaauw\Chartscss\Data\Datasets\CalculatedDataset;
 use Maartenpaauw\Chartscss\Data\Datasets\Dataset;
 use Maartenpaauw\Chartscss\Data\Datasets\DatasetContract;
+use Maartenpaauw\Chartscss\Data\Entries\CalculatedEntry;
 use Maartenpaauw\Chartscss\Data\Entries\Entry;
 use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
 use Maartenpaauw\Chartscss\Data\Label\Label;
+use Maartenpaauw\Chartscss\Statistics\CustomStatistic;
 use Maartenpaauw\Chartscss\Tests\TestCase;
 
 class CalculatedDatasetTest extends TestCase
@@ -27,7 +29,10 @@ class CalculatedDatasetTest extends TestCase
             new Entry(new Value(40), new Label('D')),
         ]);
 
-        $this->calculatedDataset = new CalculatedDataset($this->dataset, 50);
+        $this->calculatedDataset = new CalculatedDataset(
+            $this->dataset,
+            new CustomStatistic(50),
+        );
     }
 
     /** @test */
@@ -44,9 +49,16 @@ class CalculatedDatasetTest extends TestCase
     }
 
     /** @test */
-    public function it_should_return_the_origin_max(): void
+    public function it_should_wrap_each_entry_within_a_calculated_entry_decorator(): void
     {
-        $this->assertEquals($this->dataset->max(), $this->calculatedDataset->max());
+        // Act
+        [$a, $b, $c, $d] = $this->calculatedDataset->entries();
+
+        // Assert
+        $this->assertInstanceOf(CalculatedEntry::class, $a);
+        $this->assertInstanceOf(CalculatedEntry::class, $b);
+        $this->assertInstanceOf(CalculatedEntry::class, $c);
+        $this->assertInstanceOf(CalculatedEntry::class, $d);
     }
 
     /** @test */

--- a/tests/Data/Datasets/CalculatedDatasetsTest.php
+++ b/tests/Data/Datasets/CalculatedDatasetsTest.php
@@ -39,18 +39,6 @@ class CalculatedDatasetsTest extends TestCase
     }
 
     /** @test */
-    public function it_should_return_the_origin_size(): void
-    {
-        $this->assertEquals($this->datasets->size(), $this->calculatedDatasets->size());
-    }
-
-    /** @test */
-    public function it_should_return_the_origin_max(): void
-    {
-        $this->assertEquals($this->datasets->max(), $this->calculatedDatasets->max());
-    }
-
-    /** @test */
     public function it_should_return_the_origin_axes(): void
     {
         $this->assertEquals($this->datasets->axes(), $this->calculatedDatasets->axes());
@@ -65,5 +53,21 @@ class CalculatedDatasetsTest extends TestCase
         // Assert
         $this->assertInstanceOf(CalculatedDataset::class, $a);
         $this->assertInstanceOf(CalculatedDataset::class, $b);
+    }
+
+    /** @test */
+    public function it_should_use_the_maximum_entry_for_dividing(): void
+    {
+        // Act
+        [$datasetA, $datasetB] = $this->calculatedDatasets->toArray();
+
+        [$entryA, $entryB] = $datasetA->entries();
+        [$entryC, $entryD] = $datasetB->entries();
+
+        // Assert
+        $this->assertEquals('--size: calc(10 / 40);', $entryA->value()->declarations()->toString());
+        $this->assertEquals('--size: calc(20 / 40);', $entryB->value()->declarations()->toString());
+        $this->assertEquals('--size: calc(30 / 40);', $entryC->value()->declarations()->toString());
+        $this->assertEquals('--size: calc(40 / 40);', $entryD->value()->declarations()->toString());
     }
 }

--- a/tests/Data/Datasets/DatasetTest.php
+++ b/tests/Data/Datasets/DatasetTest.php
@@ -35,16 +35,10 @@ class DatasetTest extends TestCase
     }
 
     /** @test */
-    public function it_should_calculate_the_max_entry_correctly(): void
-    {
-        $this->assertEquals(70000, $this->dataset->max());
-    }
-
-    /** @test */
     public function it_should_be_an_empty_label_by_default(): void
     {
         // Arrange
-        $dataset = new Dataset([]);
+        $dataset = new Dataset();
 
         // Act
         $label = $dataset->label();
@@ -87,19 +81,5 @@ class DatasetTest extends TestCase
 
         // Assert
         $this->assertEmpty($entries);
-    }
-
-    /** @test */
-    public function it_should_have_a_maximum_default_of_zero(): void
-    {
-        // Arrange
-        $expectedMax = 0;
-        $dataset = new Dataset();
-
-        // Act
-        $max = $dataset->max();
-
-        // Assert
-        $this->assertEquals($expectedMax, $max);
     }
 }

--- a/tests/Data/Datasets/DatasetsTest.php
+++ b/tests/Data/Datasets/DatasetsTest.php
@@ -38,18 +38,6 @@ class DatasetsTest extends TestCase
     }
 
     /** @test */
-    public function it_should_calculate_the_size_correctly(): void
-    {
-        $this->assertEquals(2, $this->datasets->size());
-    }
-
-    /** @test */
-    public function it_should_calculate_the_max_data_entry_correctly(): void
-    {
-        $this->assertEquals(400000, $this->datasets->max());
-    }
-
-    /** @test */
     public function it_should_be_possible_to_retrieve_the_axes(): void
     {
         $this->assertEquals($this->axes, $this->datasets->axes());

--- a/tests/Data/Datasets/PercentageStackedDatasetsTest.php
+++ b/tests/Data/Datasets/PercentageStackedDatasetsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Tests\Data\Datasets;
+
+use Maartenpaauw\Chartscss\Data\Axes\NullAxes;
+use Maartenpaauw\Chartscss\Data\Datasets\CalculatedDataset;
+use Maartenpaauw\Chartscss\Data\Datasets\Dataset;
+use Maartenpaauw\Chartscss\Data\Datasets\Datasets;
+use Maartenpaauw\Chartscss\Data\Datasets\DatasetsContract;
+use Maartenpaauw\Chartscss\Data\Datasets\PercentageStackedDatasets;
+use Maartenpaauw\Chartscss\Data\Entries\Entry;
+use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
+use Maartenpaauw\Chartscss\Tests\TestCase;
+
+class PercentageStackedDatasetsTest extends TestCase
+{
+    private DatasetsContract $percentageStackedDatasets;
+
+    private DatasetsContract $datasets;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->datasets = new Datasets(
+            new NullAxes(),
+            new Dataset([
+                new Entry(new Value(20)),
+                new Entry(new Value(50)),
+            ]),
+            new Dataset([
+                new Entry(new Value(80)),
+                new Entry(new Value(40)),
+            ]),
+        );
+
+        $this->percentageStackedDatasets = new PercentageStackedDatasets($this->datasets);
+    }
+
+    /** @test */
+    public function it_should_return_the_origin_axes(): void
+    {
+        $this->assertEquals($this->datasets->axes(), $this->percentageStackedDatasets->axes());
+    }
+
+    /** @test */
+    public function it_should_wrap_each_dataset_within_a_calculated_dataset_decorator(): void
+    {
+        // Act
+        [$datasetA, $datasetB] = $this->percentageStackedDatasets->toArray();
+
+        // Assert
+        $this->assertInstanceOf(CalculatedDataset::class, $datasetA);
+        $this->assertInstanceOf(CalculatedDataset::class, $datasetB);
+    }
+
+    /** @test */
+    public function it_should_use_the_dataset_sum_for_dividing(): void
+    {
+        // Act
+        [$datasetA, $datasetB] = $this->percentageStackedDatasets->toArray();
+
+        [$entryA, $entryB] = $datasetA->entries();
+        [$entryC, $entryD] = $datasetB->entries();
+
+        // Assert
+        $this->assertEquals('--size: calc(20 / 70);', $entryA->value()->declarations()->toString());
+        $this->assertEquals('--size: calc(50 / 70);', $entryB->value()->declarations()->toString());
+        $this->assertEquals('--size: calc(80 / 120);', $entryC->value()->declarations()->toString());
+        $this->assertEquals('--size: calc(40 / 120);', $entryD->value()->declarations()->toString());
+    }
+}

--- a/tests/Data/Datasets/SimpleStackedDatasetsTest.php
+++ b/tests/Data/Datasets/SimpleStackedDatasetsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Tests\Data\Datasets;
+
+use Maartenpaauw\Chartscss\Data\Axes\NullAxes;
+use Maartenpaauw\Chartscss\Data\Datasets\CalculatedDataset;
+use Maartenpaauw\Chartscss\Data\Datasets\Dataset;
+use Maartenpaauw\Chartscss\Data\Datasets\Datasets;
+use Maartenpaauw\Chartscss\Data\Datasets\DatasetsContract;
+use Maartenpaauw\Chartscss\Data\Datasets\SimpleStackedDatasets;
+use Maartenpaauw\Chartscss\Data\Entries\Entry;
+use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
+use Maartenpaauw\Chartscss\Tests\TestCase;
+
+class SimpleStackedDatasetsTest extends TestCase
+{
+    private DatasetsContract $datasets;
+
+    private DatasetsContract $simpleStackedDatasets;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->datasets = new Datasets(
+            new NullAxes(),
+            new Dataset([
+                new Entry(new Value(20)),
+                new Entry(new Value(50)),
+            ]),
+            new Dataset([
+                new Entry(new Value(80)),
+                new Entry(new Value(40)),
+            ]),
+        );
+
+        $this->simpleStackedDatasets = new SimpleStackedDatasets($this->datasets);
+    }
+
+    /** @test */
+    public function it_should_return_the_origin_axes(): void
+    {
+        $this->assertEquals($this->datasets->axes(), $this->simpleStackedDatasets->axes());
+    }
+
+    /** @test */
+    public function it_should_wrap_each_dataset_within_a_calculated_dataset_decorator(): void
+    {
+        // Act
+        [$datasetA, $datasetB] = $this->simpleStackedDatasets->toArray();
+
+        // Assert
+        $this->assertInstanceOf(CalculatedDataset::class, $datasetA);
+        $this->assertInstanceOf(CalculatedDataset::class, $datasetB);
+    }
+
+    /** @test */
+    public function it_should_use_the_highest_dataset_sum_for_dividing(): void
+    {
+        // Act
+        [$datasetA, $datasetB] = $this->simpleStackedDatasets->toArray();
+
+        [$entryA, $entryB] = $datasetA->entries();
+        [$entryC, $entryD] = $datasetB->entries();
+
+        // Assert
+        $this->assertEquals('--size: calc(20 / 120);', $entryA->value()->declarations()->toString());
+        $this->assertEquals('--size: calc(50 / 120);', $entryB->value()->declarations()->toString());
+        $this->assertEquals('--size: calc(80 / 120);', $entryC->value()->declarations()->toString());
+        $this->assertEquals('--size: calc(40 / 120);', $entryD->value()->declarations()->toString());
+    }
+}

--- a/tests/Data/Datasets/StartingPointDatasetTest.php
+++ b/tests/Data/Datasets/StartingPointDatasetTest.php
@@ -9,6 +9,7 @@ use Maartenpaauw\Chartscss\Data\Entries\Entry;
 use Maartenpaauw\Chartscss\Data\Entries\StartingPointEntry;
 use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
 use Maartenpaauw\Chartscss\Data\Label\Label;
+use Maartenpaauw\Chartscss\Statistics\CustomStatistic;
 use Maartenpaauw\Chartscss\Tests\TestCase;
 
 class StartingPointDatasetTest extends TestCase
@@ -27,7 +28,10 @@ class StartingPointDatasetTest extends TestCase
             new Entry(new Value(30)),
         ], new Label('Dataset #1'));
 
-        $this->startingPointDataset = new StartingPointDataset($this->dataset, 50);
+        $this->startingPointDataset = new StartingPointDataset(
+            $this->dataset,
+            new CustomStatistic(50),
+        );
     }
 
     /** @test */
@@ -37,16 +41,13 @@ class StartingPointDatasetTest extends TestCase
     }
 
     /** @test */
-    public function it_should_return_the_max_from_the_origin_dataset(): void
-    {
-        $this->assertEquals($this->dataset->max(), $this->startingPointDataset->max());
-    }
-
-    /** @test */
     public function it_should_return_an_empty_array_when_no_entries_defined(): void
     {
         // Arrange
-        $startingPointDataset = new StartingPointDataset(new Dataset(), 10);
+        $startingPointDataset = new StartingPointDataset(
+            new Dataset(),
+            new CustomStatistic(10),
+        );
 
         // Act
         $entries = $startingPointDataset->entries();
@@ -63,7 +64,7 @@ class StartingPointDatasetTest extends TestCase
             new Dataset([
                 new Entry(new Value(20)),
             ]),
-            10,
+            new CustomStatistic(10),
         );
 
         // Act
@@ -85,5 +86,17 @@ class StartingPointDatasetTest extends TestCase
         $this->assertInstanceOf(StartingPointEntry::class, $startingPointEntryB);
         $this->assertInstanceOf(StartingPointEntry::class, $startingPointEntryC);
         $this->assertCount(3, $entries);
+    }
+
+    /** @test */
+    public function it_should_calculate_the_starting_points_correctly(): void
+    {
+        // Act
+        [$a, $b, $c] = $this->startingPointDataset->entries();
+
+        // Assert
+        $this->assertEmpty($a->value()->declarations()->toString());
+        $this->assertEquals('--start: calc(10 / 50);', $b->value()->declarations()->toString());
+        $this->assertEquals('--start: calc(20 / 50);', $c->value()->declarations()->toString());
     }
 }

--- a/tests/Data/Datasets/StartingPointDatasetsTest.php
+++ b/tests/Data/Datasets/StartingPointDatasetsTest.php
@@ -30,24 +30,12 @@ class StartingPointDatasetsTest extends TestCase
                 new Entry(new Value(20)),
             ], new Label('Dataset #1')),
             new Dataset([
-                new Entry(new Value(10)),
-                new Entry(new Value(20)),
+                new Entry(new Value(30)),
+                new Entry(new Value(40)),
             ], new Label('Dataset #2')),
         );
 
         $this->startingPointDatasets = new StartingPointDatasets($this->datasets);
-    }
-
-    /** @test */
-    public function it_should_return_the_size_of_the_origin_datasets(): void
-    {
-        $this->assertEquals($this->datasets->size(), $this->startingPointDatasets->size());
-    }
-
-    /** @test */
-    public function it_should_return_the_max_of_the_origin_datasets(): void
-    {
-        $this->assertEquals($this->datasets->max(), $this->startingPointDatasets->max());
     }
 
     /** @test */
@@ -59,8 +47,27 @@ class StartingPointDatasetsTest extends TestCase
     /** @test */
     public function it_should_wrap_each_dataset_within_a_starting_point_dataset(): void
     {
-        foreach ($this->startingPointDatasets->toArray() as $dataset) {
-            $this->assertInstanceOf(StartingPointDataset::class, $dataset);
-        }
+        // Act
+        [$a, $b] = $this->startingPointDatasets->toArray();
+
+        // Assert
+        $this->assertInstanceOf(StartingPointDataset::class, $a);
+        $this->assertInstanceOf(StartingPointDataset::class, $b);
+    }
+
+    /** @test */
+    public function it_should_use_the_highest_entry_of_all_datasets_for_dividing(): void
+    {
+        // Act
+        [$datasetA, $datasetB] = $this->startingPointDatasets->toArray();
+
+        [$entryA, $entryB] = $datasetA->entries();
+        [$entryC, $entryD] = $datasetB->entries();
+
+        // Assert
+        $this->assertEmpty($entryA->value()->declarations()->toString());
+        $this->assertEquals('--start: calc(10 / 40);', $entryB->value()->declarations()->toString());
+        $this->assertEmpty($entryC->value()->declarations()->toString());
+        $this->assertEquals('--start: calc(30 / 40);', $entryD->value()->declarations()->toString());
     }
 }

--- a/tests/Data/Datasets/Statistics/HighestDatasetSumStatisticTest.php
+++ b/tests/Data/Datasets/Statistics/HighestDatasetSumStatisticTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Tests\Data\Datasets\Statistics;
+
+use Maartenpaauw\Chartscss\Data\Axes\NullAxes;
+use Maartenpaauw\Chartscss\Data\Datasets\Dataset;
+use Maartenpaauw\Chartscss\Data\Datasets\Datasets;
+use Maartenpaauw\Chartscss\Data\Datasets\Statistics\HighestDatasetSumStatistic;
+use Maartenpaauw\Chartscss\Data\Entries\Entry;
+use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
+use PHPUnit\Framework\TestCase;
+
+class HighestDatasetSumStatisticTest extends TestCase
+{
+    /** @test */
+    public function it_should_return_the_highest_dataset_sum(): void
+    {
+        // Arrange
+        $highestDatasetSumStatistic = new HighestDatasetSumStatistic(
+            new Datasets(
+                new NullAxes(),
+                new Dataset([
+                    new Entry(new Value(10)),
+                    new Entry(new Value(30)),
+                    new Entry(new Value(60)),
+                ]),
+                new Dataset([
+                    new Entry(new Value(50)),
+                    new Entry(new Value(20)),
+                    new Entry(new Value(10)),
+                ]),
+            ),
+        );
+
+        // Act
+        $result = $highestDatasetSumStatistic->result();
+
+        // Assert
+        $this->assertEquals(100, $result);
+    }
+}

--- a/tests/Data/Datasets/Statistics/HighestEntryStatisticTest.php
+++ b/tests/Data/Datasets/Statistics/HighestEntryStatisticTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Tests\Data\Datasets\Statistics;
+
+use Maartenpaauw\Chartscss\Data\Axes\NullAxes;
+use Maartenpaauw\Chartscss\Data\Datasets\Dataset;
+use Maartenpaauw\Chartscss\Data\Datasets\Datasets;
+use Maartenpaauw\Chartscss\Data\Datasets\Statistics\HighestEntryStatistic;
+use Maartenpaauw\Chartscss\Data\Entries\Entry;
+use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
+use Maartenpaauw\Chartscss\Tests\TestCase;
+
+class HighestEntryStatisticTest extends TestCase
+{
+    /** @test */
+    public function it_should_return_the_highest_entry_of_a_given_dataset(): void
+    {
+        // Arrange
+        $expectedResult = 50;
+
+        $datasets = new Datasets(
+            new NullAxes(),
+            new Dataset([
+                new Entry(new Value(30)),
+                new Entry(new Value(10)),
+                new Entry(new Value(50)),
+                new Entry(new Value(40)),
+            ]),
+            new Dataset([
+                new Entry(new Value(10)),
+                new Entry(new Value(20)),
+                new Entry(new Value(30)),
+                new Entry(new Value(40)),
+            ])
+        );
+
+        $highestEntryStatistic = new HighestEntryStatistic($datasets);
+
+        // Act
+        $result = $highestEntryStatistic->result();
+
+        // Assert
+        $this->assertEquals($expectedResult, $result);
+    }
+}

--- a/tests/Data/Entries/CalculatedEntryTest.php
+++ b/tests/Data/Entries/CalculatedEntryTest.php
@@ -6,6 +6,7 @@ use Maartenpaauw\Chartscss\Data\Entries\CalculatedEntry;
 use Maartenpaauw\Chartscss\Data\Entries\Entry;
 use Maartenpaauw\Chartscss\Data\Entries\EntryContract;
 use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
+use Maartenpaauw\Chartscss\Statistics\CustomStatistic;
 use Maartenpaauw\Chartscss\Tests\TestCase;
 
 class CalculatedEntryTest extends TestCase
@@ -21,7 +22,7 @@ class CalculatedEntryTest extends TestCase
         $this->origin = new Entry(new Value(10));
         $this->calculatedEntry = new CalculatedEntry(
             $this->origin,
-            30,
+            new CustomStatistic(30),
         );
     }
 

--- a/tests/Data/Entries/StartingPointEntryTest.php
+++ b/tests/Data/Entries/StartingPointEntryTest.php
@@ -6,6 +6,7 @@ use Maartenpaauw\Chartscss\Data\Entries\Entry;
 use Maartenpaauw\Chartscss\Data\Entries\EntryContract;
 use Maartenpaauw\Chartscss\Data\Entries\StartingPointEntry;
 use Maartenpaauw\Chartscss\Data\Entries\Value\Value;
+use Maartenpaauw\Chartscss\Statistics\CustomStatistic;
 use Maartenpaauw\Chartscss\Tests\TestCase;
 
 class StartingPointEntryTest extends TestCase
@@ -22,7 +23,7 @@ class StartingPointEntryTest extends TestCase
         $this->startingPointEntry = new StartingPointEntry(
             $this->origin,
             new Entry(new Value(20)),
-            30,
+            new CustomStatistic(30),
         );
     }
 

--- a/tests/Data/Specifications/IsStackedTest.php
+++ b/tests/Data/Specifications/IsStackedTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Tests\Data\Specifications;
+
+use Maartenpaauw\Chartscss\Data\Axes\NullAxes;
+use Maartenpaauw\Chartscss\Data\Datasets\Datasets;
+use Maartenpaauw\Chartscss\Data\Datasets\PercentageStackedDatasets;
+use Maartenpaauw\Chartscss\Data\Datasets\SimpleStackedDatasets;
+use Maartenpaauw\Chartscss\Data\Specifications\IsStacked;
+use Maartenpaauw\Chartscss\Tests\TestCase;
+
+class IsStackedTest extends TestCase
+{
+    private IsStacked $isStacked;
+
+    private Datasets $datasets;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->isStacked = new IsStacked();
+        $this->datasets = new Datasets(new NullAxes());
+    }
+
+    /** @test */
+    public function it_should_return_true_when_a_simple_stacked_datasets_instance_is_given(): void
+    {
+        // Arrange
+        $simpleStackedDatasets = new SimpleStackedDatasets($this->datasets);
+
+        // Act
+        $satisfied = $this->isStacked->isSatisfiedBy($simpleStackedDatasets);
+
+        // Assert
+        $this->assertTrue($satisfied);
+    }
+
+    /** @test */
+    public function it_should_return_true_when_a_percentage_stacked_datasets_instance_is_given(): void
+    {
+        // Arrange
+        $percentageStackedDatasets = new PercentageStackedDatasets($this->datasets);
+
+        // Act
+        $satisfied = $this->isStacked->isSatisfiedBy($percentageStackedDatasets);
+
+        // Assert
+        $this->assertTrue($satisfied);
+    }
+
+    /** @test */
+    public function it_should_return_false_when_a_datasets_instance_is_given(): void
+    {
+        // Act
+        $satisfied = $this->isStacked->isSatisfiedBy($this->datasets);
+
+        // Assert
+        $this->assertFalse($satisfied);
+    }
+}

--- a/tests/Statistics/CustomStatisticTest.php
+++ b/tests/Statistics/CustomStatisticTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Maartenpaauw\Chartscss\Tests\Statistics;
+
+use Maartenpaauw\Chartscss\Statistics\CustomStatistic;
+use Maartenpaauw\Chartscss\Tests\TestCase;
+
+class CustomStatisticTest extends TestCase
+{
+    private CustomStatistic $customStatistic;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->customStatistic = new CustomStatistic(10);
+    }
+
+    /** @test */
+    public function it_should_return_the_given_value_correctly(): void
+    {
+        // Arrange
+        $expectedResult = 10;
+
+        // Act
+        $result = $this->customStatistic->result();
+
+        // Assert
+        $this->assertEquals($expectedResult, $result);
+    }
+}


### PR DESCRIPTION
The charts can be stacked via 2 different calculations; simple stacked and percentage stacked.